### PR TITLE
Feature/#003/member model&jwt

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 	kotlin("jvm") version "1.6.21"
 	kotlin("plugin.spring") version "1.6.21"
 	kotlin("plugin.jpa") version "1.6.21"
+	kotlin("kapt") version "1.3.61"
 }
 
 group = "me.golf"
@@ -47,10 +48,18 @@ dependencies {
 	runtimeOnly("com.h2database:h2")
 	runtimeOnly("com.mysql:mysql-connector-j")
 
+	// redis(cache)
+	implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
 	// jwt
 	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 	implementation("io.jsonwebtoken:jjwt-api:0.11.5")
 	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+
+	//QueryDSL
+	api("com.querydsl:querydsl-jpa:5.0.0")
+	kapt("com.querydsl:querydsl-apt:5.0.0:jpa")
+	kapt("org.hibernate.javax.persistence:hibernate-jpa-2.1-api:1.0.2.Final")
 
 	// test
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
@@ -74,4 +83,8 @@ tasks.withType<KotlinCompile> {
 
 tasks.withType<Test> {
 	useJUnitPlatform()
+}
+
+kotlin.sourceSets.main {
+	kotlin.srcDir("$buildDir/generated/")
 }

--- a/src/main/kotlin/me/golf/kotlin/domain/member/error/MemberNotFoundException.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/member/error/MemberNotFoundException.kt
@@ -1,0 +1,3 @@
+package me.golf.kotlin.domain.member.error
+
+class MemberNotFoundException(memberId: Long) : RuntimeException("회원을 찾을 수 없습니다. $memberId")

--- a/src/main/kotlin/me/golf/kotlin/domain/member/model/Birthday.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/member/model/Birthday.kt
@@ -7,9 +7,10 @@ import javax.persistence.Embeddable
 
 @Embeddable
 class Birthday (
-    @Column(columnDefinition = "datetime")
+    @Column(name = "birth", columnDefinition = "datetime")
     @JsonValue
-    var value: LocalDate) {
+    val value: LocalDate
+) {
 
     fun getAge(): Int {
         return LocalDate.now().year - this.value.year

--- a/src/main/kotlin/me/golf/kotlin/domain/member/model/Birthday.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/member/model/Birthday.kt
@@ -1,0 +1,36 @@
+package me.golf.kotlin.domain.member.model
+
+import com.fasterxml.jackson.annotation.JsonValue
+import java.time.LocalDate
+import javax.persistence.Column
+import javax.persistence.Embeddable
+
+@Embeddable
+class Birthday (
+    @Column(columnDefinition = "datetime")
+    @JsonValue
+    var birth: LocalDate) {
+
+    fun getAge(): Int {
+        return LocalDate.now().year - this.birth.year
+    }
+
+    fun validateExceedNowYear(birth: LocalDate): Boolean {
+        return birth > LocalDate.now()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Birthday
+
+        if (birth != other.birth) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return birth.hashCode()
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/member/model/Birthday.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/member/model/Birthday.kt
@@ -9,10 +9,10 @@ import javax.persistence.Embeddable
 class Birthday (
     @Column(columnDefinition = "datetime")
     @JsonValue
-    var birth: LocalDate) {
+    var value: LocalDate) {
 
     fun getAge(): Int {
-        return LocalDate.now().year - this.birth.year
+        return LocalDate.now().year - this.value.year
     }
 
     fun validateExceedNowYear(birth: LocalDate): Boolean {
@@ -25,12 +25,12 @@ class Birthday (
 
         other as Birthday
 
-        if (birth != other.birth) return false
+        if (value != other.value) return false
 
         return true
     }
 
     override fun hashCode(): Int {
-        return birth.hashCode()
+        return value.hashCode()
     }
 }

--- a/src/main/kotlin/me/golf/kotlin/domain/member/model/Member.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/member/model/Member.kt
@@ -34,9 +34,9 @@ class Member (
     var roleType: RoleType,
 
     @Embedded
-    var profileImage: ProfileImage?,
+    var profileImage: ProfileImage,
 
-    @Column(length = 11, nullable = false)
+    @Column(length = 20, nullable = false)
     var phoneNumber: String): BaseTimeEntity() {
 
     @Id
@@ -57,15 +57,17 @@ class Member (
         return this
     }
 
-    fun matchPassword(passwordEncoder: PasswordEncoder, password: String) {
-        if (passwordEncoder.matches(password, this.password)) {
-            throw IllegalArgumentException("password가 틀렸습니다. $password")
+    fun matchPassword(passwordEncoder: PasswordEncoder, rawPassword: String): Boolean {
+        if (passwordEncoder.matches(rawPassword, this.password)) {
+            return true
         }
+
+        return false
     }
 
     fun encodePassword(passwordEncoder: PasswordEncoder): Member {
-        passwordEncoder.encode(this.password)
-        return this;
+        this.password = passwordEncoder.encode(this.password)
+        return this
     }
 
     fun getEmailId(): String {
@@ -80,17 +82,18 @@ class Member (
         return this.birth.getAge()
     }
 
-    fun delete() {
+    fun delete(): Member {
         this.deleted = true
-    }
-
-    fun changePassword(passwordEncoder: PasswordEncoder, password: String): Member {
-        this.password = password
         return this
     }
 
-    fun validationProfileUrl(profileImage: String): Boolean {
-        return this.profileImage?.validateImagePath(profileImage) ?: true
+    fun changePassword(passwordEncoder: PasswordEncoder, password: String): Member {
+        this.password = passwordEncoder.encode(password)
+        return this
+    }
+
+    fun validationProfileUrl(profileImage: ProfileImage): Boolean {
+        return this.profileImage.validateImagePath(profileImage)
     }
 
     // equalsAndHashcode

--- a/src/main/kotlin/me/golf/kotlin/domain/member/model/Member.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/member/model/Member.kt
@@ -1,0 +1,111 @@
+package me.golf.kotlin.domain.member.model
+
+import me.golf.kotlin.global.common.BaseTimeEntity
+import org.springframework.security.crypto.password.PasswordEncoder
+import java.time.LocalDate
+import javax.persistence.*
+
+@Entity
+@Table(
+    name = "member",
+    indexes = [
+        Index(name = "i_email", columnList = "email"),
+        Index(name = "i_nickname", columnList = "nickname")
+    ]
+)
+class Member (
+    @Embedded
+    var email: UserEmail,
+
+    @Column(length = 200, nullable = false)
+    var password: String,
+
+    @Column(length = 20, nullable = false)
+    var name: String,
+
+    @Column(length = 20, unique = true, nullable = false)
+    var nickname: String,
+
+    @Embedded
+    var birth: Birthday,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var roleType: RoleType,
+
+    @Embedded
+    var profileImage: ProfileImage?,
+
+    @Column(length = 11, nullable = false)
+    var phoneNumber: String): BaseTimeEntity() {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id", nullable = false, updatable = false)
+    var id: Long = 0
+
+    @Column(nullable = false)
+    var deleted: Boolean = false
+
+    // 비즈니스 로직
+    fun updateMember(nickname: String, name: String, birth: LocalDate, profileImage: String): Member {
+        this.nickname = nickname
+        this.name = name
+        this.birth = Birthday(birth)
+        this.profileImage = ProfileImage(profileImage)
+
+        return this
+    }
+
+    fun matchPassword(passwordEncoder: PasswordEncoder, password: String) {
+        if (passwordEncoder.matches(password, this.password)) {
+            throw IllegalArgumentException("password가 틀렸습니다. $password")
+        }
+    }
+
+    fun encodePassword(passwordEncoder: PasswordEncoder): Member {
+        passwordEncoder.encode(this.password)
+        return this;
+    }
+
+    fun getEmailId(): String {
+        return this.email.getId()
+    }
+
+    fun validateExceedDate(birth: LocalDate): Boolean {
+        return this.birth.validateExceedNowYear(birth)
+    }
+
+    fun getAge(): Int {
+        return this.birth.getAge()
+    }
+
+    fun delete() {
+        this.deleted = true
+    }
+
+    fun changePassword(passwordEncoder: PasswordEncoder, password: String): Member {
+        this.password = password
+        return this
+    }
+
+    fun validationProfileUrl(profileImage: String): Boolean {
+        return this.profileImage?.validateImagePath(profileImage) ?: true
+    }
+
+    // equalsAndHashcode
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Member
+
+        if (id != other.id) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return id.hashCode()
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/member/model/ProfileImage.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/member/model/ProfileImage.kt
@@ -6,13 +6,30 @@ import javax.persistence.Embeddable
 
 @Embeddable
 class ProfileImage (
-    @Column(length = 100)
+    @Column(name = "profile_image_url", length = 100)
     @JsonValue
-    var value: String?
+    val value: String
     ) {
 
-    fun validateImagePath(profileImageUrl: String): Boolean {
+    fun validateImagePath(profileImageUrl: ProfileImage): Boolean {
         val regex = "([A-Za-z]*:\\/\\/)?\\S*".toRegex()
-        return regex.containsMatchIn(profileImageUrl)
+        return regex.containsMatchIn(profileImageUrl.value)
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ProfileImage
+
+        if (value != other.value) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return value.hashCode()
+    }
+
+
 }

--- a/src/main/kotlin/me/golf/kotlin/domain/member/model/ProfileImage.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/member/model/ProfileImage.kt
@@ -1,0 +1,18 @@
+package me.golf.kotlin.domain.member.model
+
+import com.fasterxml.jackson.annotation.JsonValue
+import javax.persistence.Column
+import javax.persistence.Embeddable
+
+@Embeddable
+class ProfileImage (
+    @Column(length = 100)
+    @JsonValue
+    var profileImageUrl: String?
+    ) {
+
+    fun validateImagePath(profileImageUrl: String): Boolean {
+        val regex = "([A-Za-z]*:\\/\\/)?\\S*".toRegex()
+        return regex.containsMatchIn(profileImageUrl)
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/member/model/ProfileImage.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/member/model/ProfileImage.kt
@@ -8,7 +8,7 @@ import javax.persistence.Embeddable
 class ProfileImage (
     @Column(length = 100)
     @JsonValue
-    var profileImageUrl: String?
+    var value: String?
     ) {
 
     fun validateImagePath(profileImageUrl: String): Boolean {

--- a/src/main/kotlin/me/golf/kotlin/domain/member/model/RoleType.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/member/model/RoleType.kt
@@ -1,0 +1,6 @@
+package me.golf.kotlin.domain.member.model
+
+enum class RoleType {
+
+    USER, ADMIN
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/member/model/UserEmail.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/member/model/UserEmail.kt
@@ -6,9 +6,9 @@ import javax.persistence.Embeddable
 
 @Embeddable
 class UserEmail(
-    @Column(unique = true, nullable = false)
+    @Column(name = "email", unique = true, nullable = false)
     @JsonValue
-    var value: String) {
+    val value: String) {
 
     fun getHost(): String {
         val index = value.indexOf("@")

--- a/src/main/kotlin/me/golf/kotlin/domain/member/model/UserEmail.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/member/model/UserEmail.kt
@@ -1,0 +1,37 @@
+package me.golf.kotlin.domain.member.model
+
+import com.fasterxml.jackson.annotation.JsonValue
+import javax.persistence.Column
+import javax.persistence.Embeddable
+
+@Embeddable
+class UserEmail(
+    @Column(unique = true, nullable = false)
+    @JsonValue
+    var email: String) {
+
+    fun getHost(): String {
+        val index = email.indexOf("@")
+        return email.substring(index + 1)
+    }
+
+    fun getId(): String {
+        val index = email.indexOf("@")
+        return email.substring(0, index)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as UserEmail
+
+        if (email != other.email) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return email.hashCode()
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/member/model/UserEmail.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/member/model/UserEmail.kt
@@ -8,16 +8,16 @@ import javax.persistence.Embeddable
 class UserEmail(
     @Column(unique = true, nullable = false)
     @JsonValue
-    var email: String) {
+    var value: String) {
 
     fun getHost(): String {
-        val index = email.indexOf("@")
-        return email.substring(index + 1)
+        val index = value.indexOf("@")
+        return value.substring(index + 1)
     }
 
     fun getId(): String {
-        val index = email.indexOf("@")
-        return email.substring(0, index)
+        val index = value.indexOf("@")
+        return value.substring(0, index)
     }
 
     override fun equals(other: Any?): Boolean {
@@ -26,12 +26,12 @@ class UserEmail(
 
         other as UserEmail
 
-        if (email != other.email) return false
+        if (value != other.value) return false
 
         return true
     }
 
     override fun hashCode(): Int {
-        return email.hashCode()
+        return value.hashCode()
     }
 }

--- a/src/main/kotlin/me/golf/kotlin/domain/member/model/repository/MemberCustomRepository.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/member/model/repository/MemberCustomRepository.kt
@@ -1,0 +1,9 @@
+package me.golf.kotlin.domain.member.model.repository
+
+import me.golf.kotlin.global.security.CustomUserDetails
+import java.util.Optional
+
+interface MemberCustomRepository {
+
+    fun getDetailById(memberId: Long): Optional<CustomUserDetails>
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/member/model/repository/MemberCustomRepositoryImpl.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/member/model/repository/MemberCustomRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package me.golf.kotlin.domain.member.model.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import me.golf.kotlin.domain.member.model.QMember
+import me.golf.kotlin.global.security.CustomUserDetails
+import me.golf.kotlin.global.security.QCustomUserDetails
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+class MemberCustomRepositoryImpl(
+    private val queryFactory: JPAQueryFactory
+) : MemberCustomRepository {
+
+    override fun getDetailById(memberId: Long): Optional<CustomUserDetails> {
+        return Optional.ofNullable(
+            queryFactory.select(
+                QCustomUserDetails(
+                    QMember.member.id,
+                    QMember.member.email,
+                    QMember.member.roleType))
+                .from(QMember.member)
+                .where(QMember.member.id.eq(memberId))
+                .fetchFirst()
+        )
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/member/model/repository/MemberRepository.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/member/model/repository/MemberRepository.kt
@@ -1,0 +1,12 @@
+package me.golf.kotlin.domain.member.model.repository;
+
+import me.golf.kotlin.domain.member.model.Member
+import me.golf.kotlin.domain.member.model.UserEmail
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MemberRepository : JpaRepository<Member, Long> {
+
+    fun existsByEmail(email: UserEmail): Boolean
+
+    fun existsByNickname(nickname: String): Boolean
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/member/model/repository/MemberRepository.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/member/model/repository/MemberRepository.kt
@@ -4,7 +4,7 @@ import me.golf.kotlin.domain.member.model.Member
 import me.golf.kotlin.domain.member.model.UserEmail
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface MemberRepository : JpaRepository<Member, Long> {
+interface MemberRepository : JpaRepository<Member, Long>, MemberCustomRepository {
 
     fun existsByEmail(email: UserEmail): Boolean
 

--- a/src/main/kotlin/me/golf/kotlin/global/common/RedisPolicy.kt
+++ b/src/main/kotlin/me/golf/kotlin/global/common/RedisPolicy.kt
@@ -1,0 +1,6 @@
+package me.golf.kotlin.global.common
+
+object RedisPolicy {
+    const val AUTH_KEY = "Authorization"
+    const val AUTH_TTL = 180L
+}

--- a/src/main/kotlin/me/golf/kotlin/global/config/QueryDSLConfig.kt
+++ b/src/main/kotlin/me/golf/kotlin/global/config/QueryDSLConfig.kt
@@ -1,0 +1,16 @@
+package me.golf.kotlin.global.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+@Configuration
+class QueryDSLConfig(
+    @PersistenceContext
+    val entityManager: EntityManager) {
+
+    @Bean
+    fun jpaQueryFactory() = JPAQueryFactory(entityManager)
+}

--- a/src/main/kotlin/me/golf/kotlin/global/config/RedisConfig.kt
+++ b/src/main/kotlin/me/golf/kotlin/global/config/RedisConfig.kt
@@ -1,0 +1,46 @@
+package me.golf.kotlin.global.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import me.golf.kotlin.global.common.RedisPolicy
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import java.time.Duration
+
+@Configuration
+class RedisConfig(
+    @Value("\${spring.redis.host}") private val host: String,
+    @Value("\${spring.redis.port}") private val port: Int,
+) {
+
+    @Bean
+    fun redisConnectionFactory(): RedisConnectionFactory = LettuceConnectionFactory(host, port)
+
+    @Bean
+    fun redisCacheManager(): RedisCacheManager {
+        val configuration = RedisCacheConfiguration
+            .defaultCacheConfig()
+            .disableCachingNullValues()
+            .entryTtl(Duration.ofMinutes(30))
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                StringRedisSerializer()
+            ))
+
+        val config = HashMap<String, RedisCacheConfiguration>()
+
+        config[RedisPolicy.AUTH_KEY] = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofMinutes(RedisPolicy.AUTH_TTL))
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+            .fromConnectionFactory(redisConnectionFactory())
+            .cacheDefaults(configuration)
+            .withInitialCacheConfigurations(config)
+            .build()
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/global/jwt/JwtFilter.kt
+++ b/src/main/kotlin/me/golf/kotlin/global/jwt/JwtFilter.kt
@@ -1,0 +1,42 @@
+package me.golf.kotlin.global.jwt
+
+import org.slf4j.LoggerFactory
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.util.StringUtils
+import org.springframework.web.filter.GenericFilterBean
+import javax.servlet.FilterChain
+import javax.servlet.ServletRequest
+import javax.servlet.ServletResponse
+import javax.servlet.http.HttpServletRequest
+
+class JwtFilter(private val tokenProvider: TokenProvider) : GenericFilterBean() {
+
+    override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
+        val httpServletRequest = request as HttpServletRequest
+        val jwt = resolveToken(httpServletRequest)
+        val requestURI = httpServletRequest.requestURI
+
+        if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
+            val authentication = tokenProvider.getAuthentication(jwt)
+            SecurityContextHolder.getContext().authentication = authentication
+            Companion.logger.debug("Security Context에 '{}' 인증 정보를 저장했습니다, uri: {}", authentication.name, requestURI)
+        } else {
+            Companion.logger.debug("유효한 JWT 토큰이 없습니다, uri: {}", requestURI)
+        }
+
+        chain.doFilter(request, response)
+    }
+
+    private fun resolveToken(request: HttpServletRequest): String? {
+        val bearerToken = request.getHeader(AUTHORIZATION_HEADER)
+
+        return if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            bearerToken.substring(7)
+        } else null
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(JwtFilter::class.java)
+        const val AUTHORIZATION_HEADER = "Authorization"
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/global/jwt/JwtSecurityConfig.kt
+++ b/src/main/kotlin/me/golf/kotlin/global/jwt/JwtSecurityConfig.kt
@@ -1,0 +1,18 @@
+package me.golf.kotlin.global.jwt
+
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.web.DefaultSecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+
+class JwtSecurityConfig(private val tokenProvider: TokenProvider)
+    : SecurityConfigurerAdapter<DefaultSecurityFilterChain?, HttpSecurity>() {
+
+    override fun configure(http: HttpSecurity) {
+        http
+            .addFilterBefore(
+                JwtFilter(tokenProvider),
+                UsernamePasswordAuthenticationFilter::class.java
+            )
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/global/jwt/TokenProvider.kt
+++ b/src/main/kotlin/me/golf/kotlin/global/jwt/TokenProvider.kt
@@ -1,0 +1,107 @@
+package me.golf.kotlin.global.jwt
+
+import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.MalformedJwtException
+import io.jsonwebtoken.SignatureAlgorithm
+import io.jsonwebtoken.UnsupportedJwtException
+import io.jsonwebtoken.io.Decoders
+import io.jsonwebtoken.security.Keys
+import me.golf.kotlin.global.jwt.dto.TokenBaseDto
+import me.golf.kotlin.global.security.CustomUserDetailsService
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.InitializingBean
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.stereotype.Component
+import java.security.Key
+import java.util.*
+import java.util.stream.Collectors
+
+@Component
+class TokenProvider(
+    @param:Value("\${jwt.secret}") private val secret: String,
+    @Value("\${jwt.accessToken-validity-in-seconds}") private val accessTokenValidityInSeconds: Long,
+    @Value("\${jwt.refreshToken-validity-in-seconds}") private val refreshTokenValidityInSeconds: Long,
+    private val customUserDetailsService: CustomUserDetailsService
+) : InitializingBean {
+
+    private val log = LoggerFactory.getLogger(TokenProvider::class.java)
+    private val accessTokenValidityInMilliSeconds: Long = accessTokenValidityInSeconds * 1000
+    private val refreshTokenValidityInMilliSeconds: Long = refreshTokenValidityInSeconds * 1000
+    private var key: Key? = null
+
+    companion object {
+        private const val AUTHORITIES_KEY = "Authorization"
+    }
+
+    override fun afterPropertiesSet() {
+        key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret))
+    }
+
+    fun createToken(memberId: Long, authentication: Authentication): TokenBaseDto {
+        val authorities = authentication.authorities.stream()
+            .map(GrantedAuthority::getAuthority)
+            .collect(Collectors.joining(","))
+
+        val accessTokenExpiredTime = Date(Date().time + accessTokenValidityInMilliSeconds)
+        val refreshTokenExpiredTime = Date(Date().time + refreshTokenValidityInMilliSeconds)
+
+        val accessToken = Jwts.builder()
+            .claim("memberId", memberId.toString())
+            .claim(AUTHORITIES_KEY, authorities)
+            .setExpiration(accessTokenExpiredTime)
+            .signWith(key, SignatureAlgorithm.HS512)
+            .compact()
+
+        val refreshToken = Jwts.builder()
+            .setExpiration(refreshTokenExpiredTime)
+            .signWith(key, SignatureAlgorithm.HS512)
+            .compact()
+
+        return TokenBaseDto(accessToken = accessToken, refreshToken = refreshToken)
+    }
+
+    fun getAuthentication(token: String?): Authentication {
+        val claims = Jwts.parserBuilder()
+            .setSigningKey(key)
+            .build()
+            .parseClaimsJws(token)
+            .body
+
+        val authorities = Arrays.stream(claims[AUTHORITIES_KEY]
+            .toString()
+            .split(",".toRegex()).dropLastWhile { it.isEmpty() }
+            .toTypedArray())
+            .map { role: String? -> SimpleGrantedAuthority(role) }
+            .collect(Collectors.toList())
+
+        val memberId = claims["memberId"]
+
+        val userDetails = customUserDetailsService.loadUserByUsername(memberId = memberId.toString())
+
+        return UsernamePasswordAuthenticationToken(userDetails, "", authorities)
+    }
+
+    fun validateToken(token: String?): Boolean {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token)
+            return true
+        } catch (e: io.jsonwebtoken.security.SecurityException) {
+            log.error("잘못된 JWT 서명입니다.")
+        } catch (e: MalformedJwtException) {
+            log.error("잘못된 JWT 서명입니다.")
+        } catch (e: ExpiredJwtException) {
+            log.error("만료된 JWT 토큰입니다.")
+        } catch (e: UnsupportedJwtException) {
+            log.error("지원되지 않는 JWT 토큰입니다.")
+        } catch (e: IllegalArgumentException) {
+            log.error("JWT 토큰이 잘못되었습니다.")
+        }
+
+        return false
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/global/jwt/dto/TokenBaseDto.kt
+++ b/src/main/kotlin/me/golf/kotlin/global/jwt/dto/TokenBaseDto.kt
@@ -1,0 +1,6 @@
+package me.golf.kotlin.global.jwt.dto
+
+class TokenBaseDto(
+    private var accessToken: String,
+    private var refreshToken: String
+)

--- a/src/main/kotlin/me/golf/kotlin/global/jwt/error/JwtAccessDeniedHandler.kt
+++ b/src/main/kotlin/me/golf/kotlin/global/jwt/error/JwtAccessDeniedHandler.kt
@@ -1,0 +1,19 @@
+package me.golf.kotlin.global.jwt.error
+
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.stereotype.Component
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+@Component
+class JwtAccessDeniedHandler: AccessDeniedHandler {
+
+    override fun handle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        accessDeniedException: AccessDeniedException
+    ) {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN)
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/global/jwt/error/JwtAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/me/golf/kotlin/global/jwt/error/JwtAuthenticationEntryPoint.kt
@@ -1,0 +1,21 @@
+package me.golf.kotlin.global.jwt.error
+
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+import java.io.IOException
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+@Component
+class JwtAuthenticationEntryPoint : AuthenticationEntryPoint {
+
+    @Throws(IOException::class)
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException
+    ) {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED)
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/global/security/CustomUserDetails.kt
+++ b/src/main/kotlin/me/golf/kotlin/global/security/CustomUserDetails.kt
@@ -29,7 +29,7 @@ class CustomUserDetails(
     }
 
     override fun getUsername(): String {
-        return email.email
+        return email.value
     }
 
     override fun isAccountNonExpired(): Boolean {

--- a/src/main/kotlin/me/golf/kotlin/global/security/CustomUserDetails.kt
+++ b/src/main/kotlin/me/golf/kotlin/global/security/CustomUserDetails.kt
@@ -1,5 +1,6 @@
 package me.golf.kotlin.global.security
 
+import com.querydsl.core.annotations.QueryProjection
 import me.golf.kotlin.domain.member.model.Member
 import me.golf.kotlin.domain.member.model.RoleType
 import me.golf.kotlin.domain.member.model.UserEmail
@@ -8,14 +9,17 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
 import java.util.Collections
 
-class CustomUserDetails(
+class CustomUserDetails
+
+@QueryProjection
+constructor(
     var memberId: Long,
     var email: UserEmail,
     var roleType: RoleType
 ) : UserDetails {
 
     companion object {
-        fun of (member: Member): CustomUserDetails {
+        fun of(member: Member): CustomUserDetails {
             return CustomUserDetails(memberId = member.id, email = member.email, roleType = member.roleType)
         }
     }

--- a/src/main/kotlin/me/golf/kotlin/global/security/CustomUserDetails.kt
+++ b/src/main/kotlin/me/golf/kotlin/global/security/CustomUserDetails.kt
@@ -1,0 +1,50 @@
+package me.golf.kotlin.global.security
+
+import me.golf.kotlin.domain.member.model.Member
+import me.golf.kotlin.domain.member.model.RoleType
+import me.golf.kotlin.domain.member.model.UserEmail
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.userdetails.UserDetails
+import java.util.Collections
+
+class CustomUserDetails(
+    var memberId: Long,
+    var email: UserEmail,
+    var roleType: RoleType
+) : UserDetails {
+
+    companion object {
+        fun of (member: Member): CustomUserDetails {
+            return CustomUserDetails(memberId = member.id, email = member.email, roleType = member.roleType)
+        }
+    }
+
+    override fun getAuthorities(): MutableCollection<out GrantedAuthority> {
+        return Collections.singleton(SimpleGrantedAuthority("ROLE_${roleType.name}"))
+    }
+
+    override fun getPassword(): String {
+        return ""
+    }
+
+    override fun getUsername(): String {
+        return email.email
+    }
+
+    override fun isAccountNonExpired(): Boolean {
+        return true
+    }
+
+    override fun isAccountNonLocked(): Boolean {
+        return true
+    }
+
+    override fun isCredentialsNonExpired(): Boolean {
+        return true
+    }
+
+    override fun isEnabled(): Boolean {
+        return true
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/global/security/CustomUserDetailsService.kt
+++ b/src/main/kotlin/me/golf/kotlin/global/security/CustomUserDetailsService.kt
@@ -2,6 +2,8 @@ package me.golf.kotlin.global.security
 
 import me.golf.kotlin.domain.member.error.MemberNotFoundException
 import me.golf.kotlin.domain.member.model.repository.MemberRepository
+import me.golf.kotlin.global.common.RedisPolicy
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.stereotype.Service
@@ -11,10 +13,10 @@ class CustomUserDetailsService(
     var memberRepository: MemberRepository
 ) : UserDetailsService {
 
+    @Cacheable(value = [RedisPolicy.AUTH_KEY], key = "#memberId")
     override fun loadUserByUsername(memberId: String): UserDetails {
 
-        return memberRepository.findById(memberId.toLong())
-            .map { CustomUserDetails.of(it) }
+        return memberRepository.getDetailById(memberId.toLong())
             .orElseThrow { throw MemberNotFoundException(memberId.toLong()) }
     }
 }

--- a/src/main/kotlin/me/golf/kotlin/global/security/CustomUserDetailsService.kt
+++ b/src/main/kotlin/me/golf/kotlin/global/security/CustomUserDetailsService.kt
@@ -1,0 +1,20 @@
+package me.golf.kotlin.global.security
+
+import me.golf.kotlin.domain.member.error.MemberNotFoundException
+import me.golf.kotlin.domain.member.model.repository.MemberRepository
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.stereotype.Service
+
+@Service
+class CustomUserDetailsService(
+    var memberRepository: MemberRepository
+) : UserDetailsService {
+
+    override fun loadUserByUsername(memberId: String): UserDetails {
+
+        return memberRepository.findById(memberId.toLong())
+            .map { CustomUserDetails.of(it) }
+            .orElseThrow { throw MemberNotFoundException(memberId.toLong()) }
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -21,6 +21,10 @@ spring:
     show-sql: true
     open-in-view: false
 
+  redis:
+    host: localhost
+    port: 6379
+
 jwt:
   secret: c2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQtc2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQK
   accessToken-validity-in-seconds: 7200 # 1??

--- a/src/test/kotlin/me/golf/kotlin/commonutil/JpaTest.kt
+++ b/src/test/kotlin/me/golf/kotlin/commonutil/JpaTest.kt
@@ -1,0 +1,16 @@
+package me.golf.kotlin.commonutil
+
+import me.golf.kotlin.global.config.QueryDSLConfig
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional
+@Import(QueryDSLConfig::class)
+@ActiveProfiles("test")
+class JpaTest {
+}

--- a/src/test/kotlin/me/golf/kotlin/domain/member/model/MemberTest.kt
+++ b/src/test/kotlin/me/golf/kotlin/domain/member/model/MemberTest.kt
@@ -1,0 +1,169 @@
+package me.golf.kotlin.domain.member.model
+
+import me.golf.kotlin.domain.member.util.GivenMember
+import me.golf.kotlin.domain.member.util.TestPasswordEncoder
+import org.junit.jupiter.api.Test
+
+import org.assertj.core.api.Assertions.*
+import java.time.LocalDate
+
+internal class MemberTest {
+
+    @Test
+    fun updateMember() {
+        // given
+        val member = GivenMember.toMember()
+        val name = "name"
+        val nickname = "nickname"
+        val birth = LocalDate.now()
+        val profileImage = "/Users/nokt/Desktop/image.png"
+
+        // when
+        val updateMember = member.updateMember(nickname, name, birth, profileImage)
+
+        // then
+        assertThat(updateMember.nickname).isEqualTo(nickname)
+        assertThat(updateMember.name).isEqualTo(name)
+        assertThat(updateMember.birth).isEqualTo(Birthday(birth))
+        assertThat(updateMember.profileImage).isEqualTo(ProfileImage(profileImage))
+    }
+
+    @Test
+    fun matchPassword() {
+        // given
+        val encoder = TestPasswordEncoder.init()
+        val member = GivenMember.toMember().encodePassword(encoder)
+        val originPassword = GivenMember.password
+
+        // when
+        val isMatch = member.matchPassword(encoder, originPassword)
+
+        // then
+        assertThat(isMatch).isTrue
+    }
+
+    @Test
+    fun matchPasswordFail() {
+        // given
+        val encoder = TestPasswordEncoder.init()
+        val member = GivenMember.toMember().encodePassword(encoder)
+        val originPassword = "123214312423"
+
+        // when
+        val isMatch = member.matchPassword(encoder, originPassword)
+
+        // then
+        assertThat(isMatch).isFalse
+    }
+
+    @Test
+    fun encodePassword() {
+        // given
+        val encoder = TestPasswordEncoder.init()
+        val member = GivenMember.toMember()
+        val originPassword = member.password
+
+        // when
+        val encodeMember = member.encodePassword(encoder)
+
+        // then
+        assertThat(encodeMember.password).isNotEqualTo(originPassword)
+    }
+
+    @Test
+    fun getEmailId() {
+        // given
+        val member = GivenMember.toMember()
+
+        // when
+        val emailId = member.getEmailId();
+
+        // then
+        assertThat(emailId).isEqualTo("ilgolc")
+    }
+
+    @Test
+    fun validateExceedDate() {
+        // given
+        val member = GivenMember.toMember()
+        val exceededBirth = LocalDate.of(2023, 12, 31)
+
+        // when
+        val isExceed = member.validateExceedDate(exceededBirth)
+
+        // then
+        assertThat(isExceed).isTrue
+    }
+
+    @Test
+    fun getAge() {
+        // given
+        val member = GivenMember.toMember()
+
+        // when
+        val age = member.getAge()
+
+        // then
+        assertThat(age).isEqualTo(26)
+    }
+
+    @Test
+    fun delete() {
+        // given
+        val member = GivenMember.toMember()
+
+        // when
+        val deletedMember = member.delete()
+
+        // then
+        assertThat(deletedMember.deleted).isTrue
+    }
+
+    @Test
+    fun changePassword() {
+        // given
+        val encoder = TestPasswordEncoder.init()
+        val member = GivenMember.toMember()
+
+        // when
+        val changePasswordMember = member.changePassword(encoder, "3456")
+
+        // then
+        changePasswordMember.matchPassword(encoder, "3456")
+    }
+
+    @Test
+    fun validationProfileUrl() {
+        // given
+        val member = GivenMember.toMember()
+        member.profileImage = ProfileImage("/User/nokt/program/image.png")
+
+        // when
+        val isProfileUrl = member.validationProfileUrl(member.profileImage)
+
+        // then
+        assertThat(isProfileUrl).isTrue
+    }
+
+    @Test
+    fun equalTest() {
+        // given
+        val member1 = GivenMember.toMember()
+        member1.id = 4L
+
+        val member2 = Member(
+            email = UserEmail("nokt@naver.com"),
+            password = "3234",
+            name = "김딱구",
+            nickname = "응애",
+            birth = Birthday(LocalDate.of(1996, 11, 2)),
+            RoleType.USER,
+            profileImage = GivenMember.profileImage,
+            phoneNumber = "010-2344-1233"
+        )
+        member2.id = 4L
+
+        // when, then
+        assertThat(member1).isEqualTo(member2)
+    }
+}

--- a/src/test/kotlin/me/golf/kotlin/domain/member/model/repository/MemberCustomRepositoryImplTest.kt
+++ b/src/test/kotlin/me/golf/kotlin/domain/member/model/repository/MemberCustomRepositoryImplTest.kt
@@ -1,0 +1,41 @@
+package me.golf.kotlin.domain.member.model.repository
+
+import me.golf.kotlin.commonutil.JpaTest
+import me.golf.kotlin.domain.member.error.MemberNotFoundException
+import me.golf.kotlin.domain.member.model.Member
+import me.golf.kotlin.domain.member.util.GivenMember
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.beans.factory.annotation.Autowired
+
+internal class MemberCustomRepositoryImplTest
+
+@Autowired constructor(
+    private val memberRepository: MemberRepository
+): JpaTest() {
+
+    companion object {
+        var member: Member = GivenMember.toMember()
+    }
+
+    @BeforeEach
+    fun init() {
+        member = memberRepository.save(GivenMember.toMember())
+    }
+
+    @Test
+    fun getDetailById() {
+        // given
+
+        // when
+        val customUserDetails = memberRepository.getDetailById(member.id)
+            .orElseThrow { throw MemberNotFoundException(member.id) }
+
+        // then
+        assertThat(customUserDetails.memberId).isEqualTo(member.id)
+    }
+}

--- a/src/test/kotlin/me/golf/kotlin/domain/member/util/GivenMember.kt
+++ b/src/test/kotlin/me/golf/kotlin/domain/member/util/GivenMember.kt
@@ -1,0 +1,27 @@
+package me.golf.kotlin.domain.member.util
+
+import me.golf.kotlin.domain.member.model.*
+import java.time.LocalDate
+
+object GivenMember {
+    val email = UserEmail("ilgolc@naver.com")
+    const val password = "1234"
+    const val name = "노경태"
+    const val nickname = "nokt"
+    val birth = Birthday(LocalDate.of(1996, 10, 25))
+    const val phoneNumber = "010-1234-5678"
+    val profileImage = ProfileImage("/Users/test/config/image.png")
+
+
+    fun toMember() =
+        Member(
+            email = email,
+            password = password,
+            name = name,
+            nickname = nickname,
+            birth = birth,
+            roleType = RoleType.USER,
+            profileImage = profileImage,
+            phoneNumber = phoneNumber
+        )
+}

--- a/src/test/kotlin/me/golf/kotlin/domain/member/util/TestPasswordEncoder.kt
+++ b/src/test/kotlin/me/golf/kotlin/domain/member/util/TestPasswordEncoder.kt
@@ -1,0 +1,24 @@
+package me.golf.kotlin.domain.member.util
+
+import org.springframework.security.crypto.bcrypt.BCrypt
+import org.springframework.security.crypto.password.PasswordEncoder
+
+class TestPasswordEncoder: PasswordEncoder {
+
+    companion object {
+        private const val LOG_ROUNDS = 4;
+        fun init() = TestPasswordEncoder()
+    }
+
+    override fun encode(rawPassword: CharSequence): String {
+        return BCrypt.hashpw(rawPassword.toString(), BCrypt.gensalt(LOG_ROUNDS))
+    }
+
+    override fun matches(rawPassword: CharSequence, encodedPassword: String): Boolean {
+        return BCrypt.checkpw(rawPassword.toString(), encodedPassword)
+    }
+
+    override fun upgradeEncoding(encodedPassword: String): Boolean {
+        return super.upgradeEncoding(encodedPassword)
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -16,6 +16,10 @@ spring:
     console:
       enabled: true
 
+  redis:
+    host: localhost
+    port: 6379
+
   jpa:
     hibernate:
       ddl-auto: create


### PR DESCRIPTION
1. 인증 정보 데이터를 자주 가져와야하므로 데이터 간소화를 위해 QueryDSL을 도입

2. 인증 정보는 자주 조회되는 데이터이므로 캐싱을 통해 인증 filter를 거칠 때 빠른 성능을 보유해야함 -> redis 도입

3. 코드 개선 및 Test Case 작성 커버리지 Member 기준 method 90%