### PR TITLE
#32, 간편 결제와 환불 기능을 제공해줄 수 있다. (Message Queue를 이용하여 비동기 처리)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,11 @@ dependencies {
 	annotationProcessor("org.projectlombok:lombok")
 
 	// webflux
-	implementation("org.springframework.boot:spring-boot-starter-webflux:2.7.5")
+	implementation("org.springframework.boot:spring-boot-starter-webflux")
+
+	// RabbitMQ
+	implementation("org.springframework.boot:spring-boot-starter-amqp")
+	implementation("org.springframework.retry:spring-retry")
 
 	// Database
 	runtimeOnly("com.h2database:h2")
@@ -66,6 +70,10 @@ dependencies {
 
 	//coolSMS
 	implementation("net.nurigo:sdk:4.2.4")
+
+	//coroutine
+	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
 
 	// test
 	testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,18 @@ services:
     volumes:
       - /Users/nogyeongtae/Shared/data/golf-redis:/var/lib/redis
 
+  rabbitmq:
+    image: rabbitmq:3.9.5-management
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    volumes:
+      - ~/.docker-conf/rabbitmq/data/:/var/lib/rabbitmq/mnesia/
+      - ./rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
+    environment:
+      RABBITMQ_DEFAULT_USER: "nokt"
+      RABBITMQ_DEFAULT_PASS: "1234"
+
   app:
     image: ilgolf/bank:latest
     container_name: bank
@@ -49,3 +61,4 @@ services:
     depends_on:
       - mysql_db
       - redis
+      - rabbitmq

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/client/DefaultBankAccountApiClient.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/client/DefaultBankAccountApiClient.kt
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 
 @Component
-@Profile("test")
+@Profile("local", "test")
 class DefaultBankAccountApiClient: BankAccountApiClient {
 
     override fun publishRegisterNumberConnection(publishRegisterNumberRequestDto: PublishRegisterNumberRequestDto): String {

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/dto/FinAccountAndBankIdDto.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/dto/FinAccountAndBankIdDto.kt
@@ -1,0 +1,11 @@
+package me.golf.kotlin.domain.bank.dto
+
+import com.querydsl.core.annotations.QueryProjection
+
+data class FinAccountAndBankIdDto
+
+@QueryProjection
+constructor(
+    val bankId: Long,
+    val finAccount: String
+)

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/history/application/PaymentHistoryService.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/history/application/PaymentHistoryService.kt
@@ -1,22 +1,31 @@
 package me.golf.kotlin.domain.bank.history.application
 
 import me.golf.kotlin.domain.bank.history.dto.HistorySummaryResponseDto
+import me.golf.kotlin.domain.bank.history.model.TransferHistory
 import me.golf.kotlin.domain.bank.history.model.TransferHistoryRepository
+import me.golf.kotlin.domain.bank.payment.dto.TransferResultDto
 import me.golf.kotlin.global.common.SliceCustomResponse
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
-class TransferHistoryService(
+class PaymentHistoryService(
     private val transferHistoryRepository: TransferHistoryRepository
 ) {
 
 
+    @Transactional(readOnly = true)
     fun getHistories(memberId: Long, bankAccountId: Long, pageable: Pageable): SliceCustomResponse<HistorySummaryResponseDto> {
         val responseDto: Slice<HistorySummaryResponseDto> =
             transferHistoryRepository.findHistoryByBankAccountId(bankAccountId, memberId, pageable)
 
         return SliceCustomResponse.of(responseDto)
+    }
+
+    @Transactional
+    fun save(resultDto: TransferResultDto): TransferHistory {
+        return transferHistoryRepository.save(resultDto.toTransferHistory())
     }
 }

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/history/model/TransferHistory.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/history/model/TransferHistory.kt
@@ -3,6 +3,7 @@ package me.golf.kotlin.domain.bank.history.model
 import lombok.AccessLevel
 import lombok.NoArgsConstructor
 import me.golf.kotlin.domain.bank.model.BankAccount
+import me.golf.kotlin.global.common.BaseEntity
 import me.golf.kotlin.global.common.BaseTimeEntity
 import java.math.BigDecimal
 import javax.persistence.*
@@ -10,6 +11,8 @@ import javax.persistence.*
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 class TransferHistory(
+
+    @Column(name = "transferMoney", nullable = false)
     var transferMoney: BigDecimal,
 
     @Column(name = "client_id", nullable = false)
@@ -20,8 +23,12 @@ class TransferHistory(
 
     @Column(name = "transfer_status", nullable = false)
     @Enumerated(EnumType.STRING)
-    var transferStatus: TransferStatus
-): BaseTimeEntity() {
+    var transferStatus: TransferStatus,
+
+    @Column(name = "result_message")
+    var resultMessage: String
+
+): BaseEntity() {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "transfer_history_id", updatable = false, nullable = false)

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/model/BankAccountCustomRepository.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/model/BankAccountCustomRepository.kt
@@ -1,10 +1,13 @@
 package me.golf.kotlin.domain.bank.model
 
 import me.golf.kotlin.domain.bank.dto.BankAccountSummaryWithFinAccount
+import me.golf.kotlin.domain.bank.dto.FinAccountAndBankIdDto
+import me.golf.kotlin.domain.bank.payment.dto.FinAccountDto
 
 interface BankAccountCustomRepository {
 
     fun findSummaryByMemberId(memberId: Long): List<BankAccountSummaryWithFinAccount>
 
     fun updateFinAccountAndRegisterNumber(finAccount: String, registerNumber: String, bankAccountId: Long)
+    fun findFinAccountBy(bankId: Long): FinAccountAndBankIdDto?
 }

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/model/BankAccountCustomRepositoryImpl.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/model/BankAccountCustomRepositoryImpl.kt
@@ -2,8 +2,11 @@ package me.golf.kotlin.domain.bank.model
 
 import com.querydsl.jpa.impl.JPAQueryFactory
 import me.golf.kotlin.domain.bank.dto.BankAccountSummaryWithFinAccount
+import me.golf.kotlin.domain.bank.dto.FinAccountAndBankIdDto
 import me.golf.kotlin.domain.bank.dto.QBankAccountSummaryWithFinAccount
+import me.golf.kotlin.domain.bank.dto.QFinAccountAndBankIdDto
 import me.golf.kotlin.domain.bank.model.QBankAccount.*
+import me.golf.kotlin.domain.bank.payment.dto.FinAccountDto
 import org.springframework.transaction.annotation.Transactional
 
 open class BankAccountCustomRepositoryImpl(
@@ -31,5 +34,14 @@ open class BankAccountCustomRepositoryImpl(
             .set(bankAccount.registerNumber, registerNumber)
             .where(bankAccount.id.eq(bankAccountId))
             .execute()
+    }
+
+    override fun findFinAccountBy(bankId: Long): FinAccountAndBankIdDto? {
+        return query.select(QFinAccountAndBankIdDto(
+            bankAccount.id,
+            bankAccount.finAccount))
+            .from(bankAccount)
+            .where(bankAccount.id.eq(bankId))
+            .fetchOne()
     }
 }

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/nh/NhApiClientImpl.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/nh/NhApiClientImpl.kt
@@ -16,7 +16,7 @@ import java.net.URI
 import java.util.stream.Collectors
 
 @Component
-@Profile("dev", "prd", "local")
+@Profile("dev", "prd")
 class NhApiClientImpl(
     private val webClient: WebClient
 ) : BankAccountApiClient {

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/nh/dto/NhCommonRequestHeader.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/nh/dto/NhCommonRequestHeader.kt
@@ -6,26 +6,26 @@ data class NhCommonRequestHeader(
 
 
     @field:JsonProperty("ApiNm")
-    val ApiNm: String,
+    val apiNm: String,
 
     @field:JsonProperty("Tsymd")
-    val Tsymd: String,
+    val tsymd: String,
 
     @field:JsonProperty("Trtm")
-    val Trtm: String,
+    val trtm: String,
 
     @field:JsonProperty("Iscd")
-    val Iscd: String,
+    val iscd: String,
 
     @field:JsonProperty("FintechApsno")
-    val FintechApsno: String,
+    val fintechApsno: String,
 
     @field:JsonProperty("ApiSvcCd")
-    val APISvcCd: String,
+    val apiSvcCd: String,
 
     @field:JsonProperty("IsTuno")
-    val Istuno: String,
+    val istuno: String,
 
     @field:JsonProperty("AccessToken")
-    val AccessToken: String
+    val accessToken: String
 )

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/nh/utils/NhHeaderValueUtils.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/nh/utils/NhHeaderValueUtils.kt
@@ -6,6 +6,8 @@ object NhHeaderValueUtils {
 
     const val FIN_ACCOUNT_API_NAME_VALUE = "OpenFinAccountDirect"
     const val BALANCE_API_NAME_VALUE = "InquireBalance"
+    const val PAYMENT_API_NAME_VALUE = "DrawingTransfer"
+    const val REFUND_API_NAME_VALUE = "ReceivedTransferAccountNumber"
     const val GET_FIN_ACCOUNT_API_NAME_VALUE = "CheckOpenFinAccountDirect"
     const val AGENCY_CODE_VALUE = "001697"
     const val FINTECH_NUMBER_VALUE = "001"

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/nh/utils/NhUrlUtils.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/nh/utils/NhUrlUtils.kt
@@ -5,4 +5,6 @@ object NhUrlUtils {
     const val FIN_ACCOUNT_URL = "https://developers.nonghyup.com/OpenFinAccountDirect.nh"
     const val FIND_BALANCE_URL = "https://developers.nonghyup.com/InquireBalance.nh"
     const val GET_FIN_ACCOUNT_URL = "https://developers.nonghyup.com/CheckOpenFinAccountDirect.nh"
+    const val PAYMENT_URL = "https://developers.nonghyup.com/DrawingTransfer.nh"
+    const val DEPOSIT_URL = "https://developers.nonghyup.com/ReceivedTransferAccountNumber.nh"
 }

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/application/DefaultPaymentService.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/application/DefaultPaymentService.kt
@@ -1,0 +1,17 @@
+package me.golf.kotlin.domain.bank.payment.application
+
+import me.golf.kotlin.domain.bank.payment.dto.RefundRequestDto
+import me.golf.kotlin.domain.bank.payment.dto.TransferRequestDto
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Service
+
+@Service
+@Profile("local", "test")
+class DefaultPaymentService: PaymentService {
+
+    override fun pay(requestDto: TransferRequestDto) {
+    }
+
+    override fun refund(requestDto: RefundRequestDto) {
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/application/PaymentProcessor.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/application/PaymentProcessor.kt
@@ -1,0 +1,65 @@
+package me.golf.kotlin.domain.bank.payment.application
+
+import me.golf.kotlin.domain.bank.history.application.PaymentHistoryService
+import me.golf.kotlin.domain.bank.history.model.TransferStatus
+import me.golf.kotlin.domain.bank.payment.client.PaymentApiClient
+import me.golf.kotlin.domain.bank.payment.dto.PaymentMessageRequestDto
+import me.golf.kotlin.domain.bank.payment.dto.RefundMessageRequestDto
+import me.golf.kotlin.domain.bank.payment.dto.TransferResultDto
+import me.golf.kotlin.global.common.PaymentMqPolicy
+import org.slf4j.LoggerFactory
+import org.springframework.amqp.rabbit.annotation.RabbitListener
+import org.springframework.context.annotation.Profile
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Retryable
+import org.springframework.stereotype.Component
+
+@Component
+@Profile("dev", "prd")
+class PaymentProcessor(
+    private val paymentApiClient: PaymentApiClient,
+    private val paymentHistoryService: PaymentHistoryService
+) {
+
+    private val log = LoggerFactory.getLogger(PaymentProcessor::class.java)
+
+    @RabbitListener(queues = [PaymentMqPolicy.PAYMENT_QUEUE])
+    fun subscribePayment(requestDto: PaymentMessageRequestDto) {
+
+        // request payment
+        log.info("payment enqueue success : {}", requestDto.fromName)
+
+        val resultMessage = paymentApiClient.pay(requestDto.finAccount, requestDto.transferMoney)
+
+        val resultDto = TransferResultDto.createWithdrawal(
+            requestDto.bankId,
+            requestDto.fromName,
+            requestDto.transferMoney,
+            resultMessage,
+            requestDto.clientId
+        )
+
+        // save history
+        paymentHistoryService.save(resultDto)
+    }
+
+    @RabbitListener(queues = [PaymentMqPolicy.REFUND_QUEUE])
+    fun subscribeRefund(requestDto: RefundMessageRequestDto) {
+        // request refund
+        log.info("refund enqueue success : {}", requestDto.fromName)
+
+        val resultMessage = paymentApiClient.refund(requestDto)
+
+        val resultDto = TransferResultDto(
+            requestDto.bankId,
+            requestDto.fromName,
+            requestDto.transferMoney,
+            TransferStatus.DEPOSIT,
+            resultMessage,
+            requestDto.clientId
+        )
+
+        // save history
+        paymentHistoryService.save(resultDto)
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/application/PaymentQueueService.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/application/PaymentQueueService.kt
@@ -1,0 +1,34 @@
+package me.golf.kotlin.domain.bank.payment.application
+
+import me.golf.kotlin.domain.bank.error.BankAccountException
+import me.golf.kotlin.domain.bank.model.BankAccountRepository
+import me.golf.kotlin.domain.bank.payment.dto.RefundRequestDto
+import me.golf.kotlin.domain.bank.payment.dto.TransferRequestDto
+import org.springframework.amqp.rabbit.core.RabbitTemplate
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Service
+
+@Service
+@Profile("dev", "prd")
+class PaymentQueueService(
+    private val bankAccountRepository: BankAccountRepository,
+    private val rabbitTemplate: RabbitTemplate,
+    @Value("\${message.queue.payment-queue}") private val paymentQueueName: String,
+    @Value("\${message.queue.refund-queue}") private val refundQueueName: String,
+    @Value("\${message.queue.topic-key}") private val topicKey: String
+): PaymentService {
+
+    override fun pay(requestDto: TransferRequestDto) {
+        val dto = bankAccountRepository.findFinAccountBy(requestDto.bankId)
+            ?: throw BankAccountException.NotFoundException()
+
+        val messageRequestDto = requestDto.toPaymentMessageRequestDto(dto.finAccount)
+
+        rabbitTemplate.convertAndSend(topicKey, paymentQueueName, messageRequestDto)
+    }
+
+    override fun refund(requestDto: RefundRequestDto) {
+        rabbitTemplate.convertAndSend(topicKey, refundQueueName, requestDto.toRefundQueueRequestDto())
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/application/PaymentService.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/application/PaymentService.kt
@@ -1,0 +1,11 @@
+package me.golf.kotlin.domain.bank.payment.application
+
+import me.golf.kotlin.domain.bank.payment.dto.RefundRequestDto
+import me.golf.kotlin.domain.bank.payment.dto.TransferRequestDto
+
+interface PaymentService {
+
+    fun pay(requestDto: TransferRequestDto)
+
+    fun refund(requestDto: RefundRequestDto)
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/client/DefaultPaymentApiClient.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/client/DefaultPaymentApiClient.kt
@@ -1,0 +1,19 @@
+package me.golf.kotlin.domain.bank.payment.client
+
+import me.golf.kotlin.domain.bank.payment.dto.RefundMessageRequestDto
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+
+@Component
+@Profile("local", "test")
+class DefaultPaymentApiClient: PaymentApiClient {
+
+    override fun pay(finAccount: String, transferMoney: BigDecimal): String {
+        return ""
+    }
+
+    override fun refund(requestDto: RefundMessageRequestDto): String {
+        return ""
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/client/PaymentApiClient.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/client/PaymentApiClient.kt
@@ -1,0 +1,10 @@
+package me.golf.kotlin.domain.bank.payment.client
+
+import me.golf.kotlin.domain.bank.payment.dto.RefundMessageRequestDto
+import java.math.BigDecimal
+
+interface PaymentApiClient {
+
+    fun pay(finAccount: String, transferMoney: BigDecimal): String
+    fun refund(requestDto: RefundMessageRequestDto): String
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/CheckAccountHolderApiRequestDto.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/CheckAccountHolderApiRequestDto.kt
@@ -1,0 +1,18 @@
+package me.golf.kotlin.domain.bank.payment.dto
+
+import me.golf.kotlin.domain.bank.model.BankName
+import javax.validation.constraints.NotBlank
+
+data class CheckAccountHolderApiRequestDto(
+
+    @NotBlank(message = "필수 값입니다.")
+    val bankName: String,
+
+    @NotBlank(message = "필수 값입니다.")
+    val number: String
+) {
+    fun toServiceDto() = CheckAccountHolderRequestDto(
+        bankName = BankName.of(bankName),
+        number = this.number
+    )
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/CheckAccountHolderRequestDto.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/CheckAccountHolderRequestDto.kt
@@ -1,0 +1,9 @@
+package me.golf.kotlin.domain.bank.payment.dto
+
+import me.golf.kotlin.domain.bank.model.BankName
+
+data class CheckAccountHolderRequestDto(
+
+    val bankName: BankName,
+    val number: String
+)

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/CheckAccountHolderResponseDto.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/CheckAccountHolderResponseDto.kt
@@ -1,0 +1,5 @@
+package me.golf.kotlin.domain.bank.payment.dto
+
+data class CheckAccountHolderResponseDto(
+    val name: String
+)

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/FinAccountDto.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/FinAccountDto.kt
@@ -1,0 +1,5 @@
+package me.golf.kotlin.domain.bank.payment.dto
+
+data class FinAccountDto(
+    val finAccount: String
+)

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/PaymentApiRequestDto.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/PaymentApiRequestDto.kt
@@ -1,0 +1,27 @@
+package me.golf.kotlin.domain.bank.payment.dto
+
+import java.math.BigDecimal
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotNull
+
+data class PaymentApiRequestDto(
+
+    @NotNull(message = "필수 값입니다.")
+    val bankId: Long,
+
+    @NotBlank(message = "필수 값입니다.")
+    val fromName: String,
+
+    @NotBlank(message = "필수 값입니다.")
+    val transferMoney: String
+) {
+
+    fun toServiceDto(memberId: Long): TransferRequestDto {
+        return TransferRequestDto(
+            bankId = this.bankId,
+            fromName = this.fromName,
+            transferMoney = BigDecimal(transferMoney),
+            memberId = memberId
+        )
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/PaymentMessageRequestDto.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/PaymentMessageRequestDto.kt
@@ -1,0 +1,11 @@
+package me.golf.kotlin.domain.bank.payment.dto
+
+import java.math.BigDecimal
+
+data class PaymentMessageRequestDto(
+    val bankId: Long,
+    val finAccount: String,
+    val transferMoney: BigDecimal,
+    val fromName: String,
+    val clientId: Long
+)

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/RefundApiRequestDto.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/RefundApiRequestDto.kt
@@ -1,0 +1,25 @@
+package me.golf.kotlin.domain.bank.payment.dto
+
+import me.golf.kotlin.domain.bank.model.BankName
+import java.math.BigDecimal
+
+data class RefundApiRequestDto(
+    val bankId: Long,
+    val accountNumber: String,
+    val fromName: String,
+    val bankName: String,
+    val transferMoney: String,
+    val refundCause: String
+) {
+    fun toServiceDto(memberId: Long): RefundRequestDto {
+        return RefundRequestDto(
+            bankId = this.bankId,
+            accountNumber = this.accountNumber,
+            fromName = this.fromName,
+            bankName = BankName.of(bankName),
+            transferMoney = BigDecimal(this.transferMoney),
+            refundCause = this.refundCause,
+            memberId = memberId
+        )
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/RefundMessageRequestDto.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/RefundMessageRequestDto.kt
@@ -1,0 +1,14 @@
+package me.golf.kotlin.domain.bank.payment.dto
+
+import me.golf.kotlin.domain.bank.model.BankName
+import java.math.BigDecimal
+
+data class RefundMessageRequestDto(
+    val bankId: Long,
+    val accountNumber: String,
+    val transferMoney: BigDecimal,
+    val refundCause: String,
+    val fromName: String,
+    val bankName: BankName,
+    val clientId: Long
+)

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/RefundRequestDto.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/RefundRequestDto.kt
@@ -1,0 +1,26 @@
+package me.golf.kotlin.domain.bank.payment.dto
+
+import me.golf.kotlin.domain.bank.model.BankName
+import java.math.BigDecimal
+
+data class RefundRequestDto(
+    val bankId: Long,
+    val accountNumber: String,
+    val fromName: String,
+    val bankName: BankName,
+    val transferMoney: BigDecimal,
+    val refundCause: String,
+    val memberId: Long
+) {
+    fun toRefundQueueRequestDto(): RefundMessageRequestDto {
+        return RefundMessageRequestDto(
+            this.bankId,
+            this.accountNumber,
+            this.transferMoney,
+            this.refundCause,
+            this.fromName,
+            this.bankName,
+            this.memberId
+        )
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/SimplePaymentResponseDto.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/SimplePaymentResponseDto.kt
@@ -1,0 +1,31 @@
+package me.golf.kotlin.domain.bank.payment.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import me.golf.kotlin.domain.bank.nh.dto.NhCommonResponseHeader
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+data class SimplePaymentResponseDto(
+
+    @field:JsonProperty("FinAcno")
+    val finAccount: String,
+
+    @field:JsonProperty("Header")
+    val header: NhCommonResponseHeader,
+
+    @field:JsonProperty("RgsnYmd")
+    val registerDate: String
+) {
+
+    companion object {
+        fun createDefault(finAccount: String): SimplePaymentResponseDto {
+            val formatter = DateTimeFormatter.ofPattern("yyyyMMdd")
+
+            return SimplePaymentResponseDto(
+                finAccount,
+                NhCommonResponseHeader(),
+                formatter.format(LocalDate.now())
+            )
+        }
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/SimpleRefundResponseDto.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/SimpleRefundResponseDto.kt
@@ -1,0 +1,18 @@
+package me.golf.kotlin.domain.bank.payment.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import me.golf.kotlin.domain.bank.nh.dto.NhCommonResponseHeader
+
+data class SimpleRefundResponseDto(
+
+    @field:JsonProperty("Header")
+    val header: NhCommonResponseHeader,
+) {
+
+    companion object {
+
+        fun createDefault(): SimpleRefundResponseDto {
+            return SimpleRefundResponseDto(NhCommonResponseHeader())
+        }
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/SimpleTransferResponseDto.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/SimpleTransferResponseDto.kt
@@ -1,0 +1,5 @@
+package me.golf.kotlin.domain.bank.payment.dto
+
+data class SimpleTransferResponseDto(
+    val responseMessage: String
+)

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/TransferCheckStatusResponseDto.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/TransferCheckStatusResponseDto.kt
@@ -1,0 +1,5 @@
+package me.golf.kotlin.domain.bank.payment.dto
+
+data class TransferCheckStatusResponseDto(
+    val status: String
+)

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/TransferRequestDto.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/TransferRequestDto.kt
@@ -1,0 +1,15 @@
+package me.golf.kotlin.domain.bank.payment.dto
+
+import java.math.BigDecimal
+
+data class TransferRequestDto(
+    val bankId: Long,
+    val fromName: String,
+    val transferMoney: BigDecimal,
+    val memberId: Long
+) {
+
+    fun toPaymentMessageRequestDto(finAccount: String): PaymentMessageRequestDto {
+        return PaymentMessageRequestDto(bankId, finAccount, this.transferMoney, this.fromName, this.memberId)
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/TransferResultDto.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/dto/TransferResultDto.kt
@@ -1,0 +1,47 @@
+package me.golf.kotlin.domain.bank.payment.dto
+
+import me.golf.kotlin.domain.bank.history.model.TransferHistory
+import me.golf.kotlin.domain.bank.history.model.TransferStatus
+import java.math.BigDecimal
+
+data class TransferResultDto(
+    val bankId: Long,
+    val fromName: String,
+    val transferMoney: BigDecimal,
+    val transferStatus: TransferStatus,
+    val resultMessage: String,
+    val clientId: Long
+) {
+
+    companion object {
+        fun createWithdrawal(bankId: Long, name: String, transferMoney: BigDecimal, resultMessage: String, clientId: Long) =
+            TransferResultDto(
+                bankId = bankId,
+                fromName = name,
+                transferMoney = transferMoney,
+                transferStatus = TransferStatus.WITHDRAWAL,
+                resultMessage = resultMessage,
+                clientId = clientId
+            )
+
+        fun createDeposit(bankId: Long, name: String, transferMoney: BigDecimal, resultMessage: String, clientId: Long) =
+            TransferResultDto(
+                bankId = bankId,
+                fromName = name,
+                transferMoney = transferMoney,
+                transferStatus = TransferStatus.DEPOSIT,
+                resultMessage = resultMessage,
+                clientId = clientId
+            )
+    }
+
+    fun toTransferHistory(): TransferHistory {
+        return TransferHistory(
+            transferMoney = transferMoney,
+            client = this.clientId,
+            bankId = this.bankId,
+            transferStatus = transferStatus,
+            resultMessage = resultMessage
+        )
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/exception/SimplePaymentFailException.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/exception/SimplePaymentFailException.kt
@@ -1,0 +1,6 @@
+package me.golf.kotlin.domain.bank.payment.exception
+
+import me.golf.kotlin.global.exception.error.BusinessException
+import me.golf.kotlin.global.exception.error.ErrorCode
+
+class SimplePaymentFailException(reasonPhrase: String): BusinessException(ErrorCode.PAYMENT_FAIL, reasonPhrase)

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/nh/NhPaymentApiClient.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/nh/NhPaymentApiClient.kt
@@ -1,0 +1,72 @@
+package me.golf.kotlin.domain.bank.payment.nh
+
+import me.golf.kotlin.domain.bank.nh.utils.NhUrlUtils
+import me.golf.kotlin.domain.bank.payment.client.PaymentApiClient
+import me.golf.kotlin.domain.bank.payment.dto.RefundMessageRequestDto
+import me.golf.kotlin.domain.bank.payment.dto.RefundRequestDto
+import me.golf.kotlin.domain.bank.payment.dto.SimplePaymentResponseDto
+import me.golf.kotlin.domain.bank.payment.dto.SimpleRefundResponseDto
+import me.golf.kotlin.domain.bank.payment.exception.SimplePaymentFailException
+import me.golf.kotlin.domain.bank.payment.nh.dto.SimpleDepositRequestDto
+import me.golf.kotlin.domain.bank.payment.nh.dto.SimplePaymentRequestDto
+import me.golf.kotlin.domain.bank.policy.DefaultValuePolicy.DEFAULT_NH_VALUE
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.BodyInserters
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.awaitBody
+import org.springframework.web.reactive.function.client.bodyToMono
+import reactor.core.publisher.Mono
+import java.math.BigDecimal
+import java.net.URI
+
+@Component
+@Profile("dev", "prd")
+class NhPaymentApiClient(
+    private val webClient: WebClient
+): PaymentApiClient {
+
+    override fun pay(finAccount: String, transferMoney: BigDecimal): String {
+        return webClient.post()
+            .uri(URI.create(NhUrlUtils.PAYMENT_URL))
+            .bodyValue(SimplePaymentRequestDto.of(finAccount, transferMoney))
+            .retrieve()
+            .onStatus(
+                { status -> status.is4xxClientError || status.is5xxServerError },
+                { response ->
+                    Mono.error(
+                        SimplePaymentFailException(response.statusCode().reasonPhrase)
+                    )
+                }
+            )
+            .bodyToMono<SimplePaymentResponseDto>()
+            .flux()
+            .toStream()
+            .findFirst()
+            .orElseGet { SimplePaymentResponseDto.createDefault(finAccount) }
+            .header
+            .responseMessage
+    }
+
+    override fun refund(requestDto: RefundMessageRequestDto): String {
+        return webClient.post()
+            .uri(URI.create(NhUrlUtils.DEPOSIT_URL))
+            .bodyValue(SimpleDepositRequestDto.of(requestDto))
+            .retrieve()
+            .onStatus(
+                { status -> status.is4xxClientError || status.is5xxServerError },
+                { response ->
+                    Mono.error(
+                        SimplePaymentFailException(response.statusCode().reasonPhrase)
+                    )
+                }
+            )
+            .bodyToMono<SimpleRefundResponseDto>()
+            .flux()
+            .toStream()
+            .findFirst()
+            .orElseGet { SimpleRefundResponseDto.createDefault() }
+            .header
+            .responseMessage
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/nh/dto/SimpleDepositRequestDto.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/nh/dto/SimpleDepositRequestDto.kt
@@ -1,0 +1,54 @@
+package me.golf.kotlin.domain.bank.payment.nh.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import me.golf.kotlin.domain.bank.nh.dto.NhCommonRequestHeader
+import me.golf.kotlin.domain.bank.nh.utils.NhHeaderValueUtils
+import me.golf.kotlin.domain.bank.payment.dto.RefundMessageRequestDto
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+data class SimpleDepositRequestDto (
+
+
+    @field:JsonProperty("Header")
+    val commonRequestHeader: NhCommonRequestHeader,
+
+    @field:JsonProperty("Bncd")
+    val bankCode: String,
+
+    @field:JsonProperty("Acno")
+    val accountNumber: String,
+
+    @field:JsonProperty("Tram")
+    val transferMoney: BigDecimal,
+
+    @field:JsonProperty("MracOtlt")
+    val refundCause: String
+) {
+
+    companion object {
+        fun of(requestDto: RefundMessageRequestDto): SimpleDepositRequestDto {
+            val nowDateTimeParse = LocalDateTime.now()
+                .format(DateTimeFormatter.ofPattern("yyyyMMdd hhmmss"))
+                .split(" ")
+
+            return SimpleDepositRequestDto(
+                NhCommonRequestHeader(
+                    NhHeaderValueUtils.REFUND_API_NAME_VALUE,
+                    nowDateTimeParse[0],
+                    nowDateTimeParse[1],
+                    NhHeaderValueUtils.AGENCY_CODE_VALUE,
+                    NhHeaderValueUtils.FINTECH_NUMBER_VALUE,
+                    NhHeaderValueUtils.BALANCE_SERVICE_CODE_VALUE,
+                    NhHeaderValueUtils.createAgencyDealCode().toString(),
+                    NhHeaderValueUtils.ACCESS_TOKEN_VALUE
+                ),
+                requestDto.bankName.code,
+                requestDto.accountNumber,
+                requestDto.transferMoney,
+                requestDto.refundCause
+            )
+        }
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/nh/dto/SimplePaymentRequestDto.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/nh/dto/SimplePaymentRequestDto.kt
@@ -1,0 +1,44 @@
+package me.golf.kotlin.domain.bank.payment.nh.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import me.golf.kotlin.domain.bank.nh.dto.NhCommonRequestHeader
+import me.golf.kotlin.domain.bank.nh.utils.NhHeaderValueUtils
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+class SimplePaymentRequestDto(
+
+    @field:JsonProperty("Header")
+    val nhHeader: NhCommonRequestHeader,
+
+    @field:JsonProperty("FinAcno")
+    val finAccount: String,
+
+    @field:JsonProperty("Tram")
+    val transferMoney: BigDecimal
+) {
+
+    companion object {
+        fun of(finAccount: String, transferMoney: BigDecimal): SimplePaymentRequestDto {
+            val nowDateTimeParse = LocalDateTime.now()
+                .format(DateTimeFormatter.ofPattern("yyyyMMdd hhmmss"))
+                .split(" ")
+
+            return SimplePaymentRequestDto(
+                NhCommonRequestHeader(
+                    NhHeaderValueUtils.PAYMENT_API_NAME_VALUE,
+                    nowDateTimeParse[0],
+                    nowDateTimeParse[1],
+                    NhHeaderValueUtils.AGENCY_CODE_VALUE,
+                    NhHeaderValueUtils.FINTECH_NUMBER_VALUE,
+                    NhHeaderValueUtils.FIN_ACCOUNT_SERVICE_CODE_VALUE,
+                    NhHeaderValueUtils.createAgencyDealCode().toString(),
+                    NhHeaderValueUtils.ACCESS_TOKEN_VALUE
+                ),
+                finAccount,
+                transferMoney
+            )
+        }
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/payment/presentation/PaymentController.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/payment/presentation/PaymentController.kt
@@ -1,0 +1,50 @@
+package me.golf.kotlin.domain.bank.payment.presentation
+
+import me.golf.kotlin.domain.bank.LookupType
+import me.golf.kotlin.domain.bank.RequireFinAccount
+import me.golf.kotlin.domain.bank.payment.application.PaymentService
+import me.golf.kotlin.domain.bank.payment.dto.PaymentApiRequestDto
+import me.golf.kotlin.domain.bank.payment.dto.RefundApiRequestDto
+import me.golf.kotlin.domain.bank.payment.dto.SimpleTransferResponseDto
+import me.golf.kotlin.global.security.CustomUserDetails
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import javax.validation.Valid
+
+@RestController
+@RequestMapping("/api/v2/bank-accounts")
+class PaymentController(
+    private val paymentService: PaymentService
+) {
+
+    private val log = LoggerFactory.getLogger(PaymentController::class.java)
+
+    companion object {
+        const val SUCCESS_MESSAGE = "결제 요청에 성공했습니다."
+    }
+
+    @PostMapping("/payment")
+    fun pay(
+        @Valid @RequestBody requestDto: PaymentApiRequestDto,
+        @AuthenticationPrincipal customUserDetails: CustomUserDetails
+    ): ResponseEntity<SimpleTransferResponseDto> {
+
+        paymentService.pay(requestDto.toServiceDto(customUserDetails.memberId))
+        return ResponseEntity.ok(SimpleTransferResponseDto(SUCCESS_MESSAGE))
+    }
+
+    @PostMapping("/refunds")
+    fun refund(
+        @Valid @RequestBody requestDto: RefundApiRequestDto,
+        @AuthenticationPrincipal customUserDetails: CustomUserDetails
+    ): ResponseEntity<SimpleTransferResponseDto> {
+
+        paymentService.refund(requestDto.toServiceDto(customUserDetails.memberId))
+        return ResponseEntity.ok(SimpleTransferResponseDto(SUCCESS_MESSAGE))
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/domain/bank/presentation/BankAccountController.kt
+++ b/src/main/kotlin/me/golf/kotlin/domain/bank/presentation/BankAccountController.kt
@@ -8,7 +8,7 @@ import me.golf.kotlin.domain.bank.dto.BankAccountInfoResponseDto
 import me.golf.kotlin.domain.bank.dto.BankAccountSaveApiRequestDto
 import me.golf.kotlin.domain.bank.dto.BankAccountUpdateRequestDto
 import me.golf.kotlin.domain.bank.dto.SimpleBankAccountIdResponseDto
-import me.golf.kotlin.domain.bank.history.application.TransferHistoryService
+import me.golf.kotlin.domain.bank.history.application.PaymentHistoryService
 import me.golf.kotlin.global.security.CustomUserDetails
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PageableDefault
@@ -22,7 +22,7 @@ import javax.validation.Valid
 class BankAccountController(
     private val bankAccountCommandService: BankAccountCommandService,
     private val bankAccountQueryService: BankAccountQueryService,
-    private val transferHistoryService: TransferHistoryService
+    private val paymentHistoryService: PaymentHistoryService
 ) {
 
     @PostMapping
@@ -44,7 +44,7 @@ class BankAccountController(
         val bankAccountSummaryResponseDto =
             bankAccountQueryService.getBankAccountSummary(bankAccountId, customUserDetails.memberId)
         val historyResponseDto =
-            transferHistoryService.getHistories(bankAccountId, customUserDetails.memberId, pageable)
+            paymentHistoryService.getHistories(bankAccountId, customUserDetails.memberId, pageable)
 
         return ResponseEntity.ok(BankAccountInfoResponseDto(bankAccountSummaryResponseDto, historyResponseDto))
     }

--- a/src/main/kotlin/me/golf/kotlin/global/common/PaymentMqPolicy.kt
+++ b/src/main/kotlin/me/golf/kotlin/global/common/PaymentMqPolicy.kt
@@ -1,0 +1,9 @@
+package me.golf.kotlin.global.common
+
+object PaymentMqPolicy {
+
+    const val PAYMENT_QUEUE = "paymentQueue"
+    const val REFUND_QUEUE = "refundQueue"
+    const val PAYMENT_DEAD_LETTER_QUEUE = "paymentDeadLetterQueue"
+    const val REFUND_DEAD_LETTER_QUEUE = "refundDeadLetterQueue"
+}

--- a/src/main/kotlin/me/golf/kotlin/global/config/RabbitConsumerConfig.kt
+++ b/src/main/kotlin/me/golf/kotlin/global/config/RabbitConsumerConfig.kt
@@ -1,0 +1,64 @@
+package me.golf.kotlin.global.config
+
+import me.golf.kotlin.domain.bank.payment.application.PaymentProcessor
+import org.springframework.amqp.core.Queue
+import org.springframework.amqp.rabbit.annotation.EnableRabbit
+import org.springframework.amqp.rabbit.connection.ConnectionFactory
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer
+import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter
+import org.springframework.amqp.support.converter.MessageConverter
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+
+@EnableRabbit
+@Configuration
+@Profile("dev", "prd")
+class RabbitConsumerConfig(
+    private val paymentProcessor: PaymentProcessor
+) {
+
+    @Bean
+    fun paymentListenerContainer(
+        connectionFactory: ConnectionFactory,
+        paymentQueue: Queue,
+        paymentListenerAdapter: MessageListenerAdapter
+    ): SimpleMessageListenerContainer {
+
+        val container = SimpleMessageListenerContainer()
+        container.connectionFactory = connectionFactory
+        container.setQueues(paymentQueue)
+        container.setMessageListener(paymentListenerAdapter)
+        return container
+    }
+
+    @Bean
+    fun refundListenerContainer(
+        connectionFactory: ConnectionFactory,
+        refundQueue: Queue,
+        refundListenerAdapter: MessageListenerAdapter
+    ): SimpleMessageListenerContainer {
+
+        val container = SimpleMessageListenerContainer()
+        container.connectionFactory = connectionFactory
+        container.setQueues(refundQueue)
+        container.setMessageListener(refundListenerAdapter)
+        return container
+    }
+
+    @Bean
+    fun paymentListenerAdapter(messageConverter: MessageConverter): MessageListenerAdapter {
+        val listenerAdapter = MessageListenerAdapter(paymentProcessor, "subscribePayment")
+        listenerAdapter.setMessageConverter(messageConverter)
+        listenerAdapter.setDefaultListenerMethod("subscribePayment")
+        return listenerAdapter
+    }
+
+    @Bean
+    fun refundListenerAdapter(messageConverter: MessageConverter): MessageListenerAdapter {
+        val listenerAdapter = MessageListenerAdapter(paymentProcessor, "subscribeRefund")
+        listenerAdapter.setMessageConverter(messageConverter)
+        listenerAdapter.setDefaultListenerMethod("subscribeRefund")
+        return listenerAdapter
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/global/config/RabbitMqConfig.kt
+++ b/src/main/kotlin/me/golf/kotlin/global/config/RabbitMqConfig.kt
@@ -1,0 +1,73 @@
+package me.golf.kotlin.global.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.amqp.rabbit.annotation.EnableRabbit
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory
+import org.springframework.amqp.rabbit.connection.ConnectionFactory
+import org.springframework.amqp.rabbit.core.RabbitTemplate
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.retry.RetryPolicy
+import org.springframework.retry.backoff.FixedBackOffPolicy
+import org.springframework.retry.policy.SimpleRetryPolicy
+import org.springframework.retry.support.RetryTemplate
+
+
+@EnableRabbit
+@Configuration
+@Profile("dev", "prd")
+class RabbitMqConfig(
+    @Value("\${spring.rabbitmq.host}") private val host: String,
+    @Value("\${spring.rabbitmq.username}") private val username: String,
+    @Value("\${spring.rabbitmq.port}") private val port: Int,
+    @Value("\${spring.rabbitmq.password}") private val password: String
+) {
+
+    @Bean
+    fun rabbitMqConnectionFactory(): ConnectionFactory {
+        val connectionFactory = CachingConnectionFactory()
+        connectionFactory.host = host
+        connectionFactory.username = username
+        connectionFactory.port = port
+        connectionFactory.setPassword(password)
+        return connectionFactory;
+    }
+
+    @Bean
+    fun rabbitTemplate(objectMapper: ObjectMapper): RabbitTemplate {
+        val rabbitTemplate = RabbitTemplate(rabbitMqConnectionFactory())
+        rabbitTemplate.messageConverter = messageConverter(objectMapper)
+        return rabbitTemplate
+    }
+
+    @Bean
+    fun messageConverter(objectMapper: ObjectMapper): Jackson2JsonMessageConverter {
+        return Jackson2JsonMessageConverter(objectMapper)
+    }
+
+    @Bean
+    fun rabbitListenerContainerFactory(connectionFactory: ConnectionFactory): SimpleRabbitListenerContainerFactory {
+        val factory = SimpleRabbitListenerContainerFactory()
+        factory.setConnectionFactory(connectionFactory)
+        factory.setConcurrentConsumers(1)
+        factory.setMaxConcurrentConsumers(1)
+        factory.setDefaultRequeueRejected(false)
+
+        // Set up the retry policy
+        val retryTemplate = RetryTemplate()
+        val retryPolicy = SimpleRetryPolicy(5) // Set the maximum number of retry attempts
+        val backOffPolicy = FixedBackOffPolicy()
+        backOffPolicy.backOffPeriod = 60000 // Set the backoff period to 1 minute (60000 milliseconds)
+
+        retryTemplate.setRetryPolicy(retryPolicy)
+        retryTemplate.setBackOffPolicy(backOffPolicy)
+
+        factory.setRetryTemplate(retryTemplate)
+
+        return factory
+    }
+}

--- a/src/main/kotlin/me/golf/kotlin/global/config/RabbitProducerConfig.kt
+++ b/src/main/kotlin/me/golf/kotlin/global/config/RabbitProducerConfig.kt
@@ -1,0 +1,70 @@
+package me.golf.kotlin.global.config
+
+import me.golf.kotlin.global.common.PaymentMqPolicy.PAYMENT_DEAD_LETTER_QUEUE
+import me.golf.kotlin.global.common.PaymentMqPolicy.PAYMENT_QUEUE
+import me.golf.kotlin.global.common.PaymentMqPolicy.REFUND_DEAD_LETTER_QUEUE
+import me.golf.kotlin.global.common.PaymentMqPolicy.REFUND_QUEUE
+import org.springframework.amqp.core.*
+import org.springframework.amqp.rabbit.annotation.EnableRabbit
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+
+@EnableRabbit
+@Configuration
+@Profile("dev", "prd")
+class RabbitProducerConfig(
+    @Value("\${message.queue.topic-key}") private val topicKey: String,
+    @Value("\${message.queue.dead-topic-key}") private val deadTopicKey: String
+) {
+
+    @Bean
+    fun paymentQueue(): Queue {
+        return QueueBuilder.durable(PAYMENT_QUEUE)
+            .withArgument("x-dead-letter-exchange", deadTopicKey)
+            .withArgument("x-dead-letter-routing-key", PAYMENT_DEAD_LETTER_QUEUE)
+            .build()
+    }
+
+    @Bean
+    fun refundQueue(): Queue {
+        return QueueBuilder.durable(REFUND_QUEUE)
+            .withArgument("x-dead-letter-exchange", deadTopicKey)
+            .withArgument("x-dead-letter-routing-key", REFUND_DEAD_LETTER_QUEUE)
+            .build()
+    }
+
+
+    @Bean
+    fun deadLetterQueuePayment() = Queue("deadLetterPayment", true)
+
+    @Bean
+    fun deadLetterQueueRefund() = Queue("deadLetterRefund", true)
+
+    @Bean
+    fun topicExchange(): TopicExchange {
+        return TopicExchange(topicKey)
+    }
+
+    @Bean
+    fun deadTopicKey(): TopicExchange {
+        return TopicExchange(deadTopicKey)
+    }
+
+    @Bean
+    fun paymentQueueBinding(): Binding =
+        BindingBuilder.bind(paymentQueue()).to(topicExchange()).with("payment.#")
+
+    @Bean
+    fun refundQueueBinding(): Binding =
+        BindingBuilder.bind(refundQueue()).to(topicExchange()).with("refund.#")
+
+    @Bean
+    fun deadLetterBindingPayment(): Binding =
+        BindingBuilder.bind(deadLetterQueuePayment()).to(deadTopicKey()).with("dead.payment.#")
+
+    @Bean
+    fun deadLetterBindingRefund(): Binding =
+        BindingBuilder.bind(deadLetterQueueRefund()).to(deadTopicKey()).with("dead.refund.#")
+}

--- a/src/main/kotlin/me/golf/kotlin/global/exception/error/ErrorCode.kt
+++ b/src/main/kotlin/me/golf/kotlin/global/exception/error/ErrorCode.kt
@@ -28,4 +28,7 @@ enum class ErrorCode(val message: String, val status: Int) {
     DUPLICATE_ACCOUNT_NICKNAME("이미 존재하는 계좌 별칭입니다.", 400),
     CONVERT_BANK_NAME_DENIED("변경 불가능한 은행 이름입니다. 확인해주세요", 400),
     TRY_LOCK_DENIED("정상적인 접근이 아닙니다.", 400),
+
+    // payment
+    PAYMENT_FAIL("결제에 실패했습니다.", 400),
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -24,6 +24,12 @@ spring:
     host: redis
     port: 6379
 
+  rabbitmq:
+    host: rabbitmq
+    port: 5672
+    username: usernokt
+    password: 1234
+
 jwt:
   secret: ${SECRET_KEY}
   accessToken-validity-in-seconds: 7200 # 1??
@@ -42,3 +48,11 @@ logging:
       netty:
         http:
           client: debug
+
+
+message:
+  queue:
+    topic-key: golf.payments
+    payment-queue: payment.init
+    refund-queue: refund.init
+    dead-topic-key: dead.letter.payments

--- a/src/main/resources/init.sql
+++ b/src/main/resources/init.sql
@@ -46,11 +46,17 @@ create index i_nickname on member (nickname);
 create table transfer_history
 (
     transfer_history_id bigint auto_increment not null,
-    created_at          datetime,
-    last_modified_date  datetime,
     bank_id             bigint                not null,
     client_id           bigint                not null,
-    transfer_money      numeric(19, 2),
-    transfer_status     varchar(255)          not null,
+    transfer_money      numeric(19, 2)        not null,
+    transfer_status     varchar(30)           not null,
+    result_message      varchar(255)          not null,
+    last_modified_date  datetime,
+    created_at          datetime,
+    created_by          bigint,
+    last_modified_by    bigint,
     primary key (transfer_history_id)
-)
+);
+
+create index i_bank_id on transfer_history (bank_id);
+create index i_client_id on transfer_history (client_id);

--- a/src/test/kotlin/me/golf/kotlin/domain/bank/history/application/PaymentHistoryServiceTest.kt
+++ b/src/test/kotlin/me/golf/kotlin/domain/bank/history/application/PaymentHistoryServiceTest.kt
@@ -14,14 +14,14 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.SliceImpl
 import java.time.LocalDateTime
 
-internal class TransferHistoryServiceTest {
+internal class PaymentHistoryServiceTest {
 
     private val transferHistoryRepository: TransferHistoryRepository = mockk()
-    private lateinit var transferHistoryService: TransferHistoryService
+    private lateinit var paymentHistoryService: PaymentHistoryService
 
     @BeforeEach
     fun init() {
-        transferHistoryService = TransferHistoryService(transferHistoryRepository)
+        paymentHistoryService = PaymentHistoryService(transferHistoryRepository)
     }
 
     @Test
@@ -43,7 +43,7 @@ internal class TransferHistoryServiceTest {
         every { transferHistoryRepository.findHistoryByBankAccountId(any(), any(), any()) } returns responseDtos
 
         // when
-        val histories = transferHistoryService.getHistories(1L, 1L, PageRequest.of(0, 10))
+        val histories = paymentHistoryService.getHistories(1L, 1L, PageRequest.of(0, 10))
 
         // then
         assertThat(histories.contents[0].memberNickname).isEqualTo("테스트 회원")

--- a/src/test/kotlin/me/golf/kotlin/domain/bank/history/model/TransferHistoryTest.kt
+++ b/src/test/kotlin/me/golf/kotlin/domain/bank/history/model/TransferHistoryTest.kt
@@ -16,7 +16,8 @@ internal class TransferHistoryTest {
             transferMoney = BigDecimal.valueOf(6000),
             client = 1L,
             transferStatus = TransferStatus.DEPOSIT,
-            bankId = 1L
+            bankId = 1L,
+            resultMessage = TestTransferHistoryUtils.failCause
         )
 
         val transferHistory = TestTransferHistoryUtils.toEntity()

--- a/src/test/kotlin/me/golf/kotlin/domain/bank/history/model/utils/TestTransferHistoryUtils.kt
+++ b/src/test/kotlin/me/golf/kotlin/domain/bank/history/model/utils/TestTransferHistoryUtils.kt
@@ -8,13 +8,15 @@ object TestTransferHistoryUtils {
 
     val transferMoney: BigDecimal = BigDecimal.valueOf(5000)
     const val client = "테스트용 클라이언트"
+    const val failCause = "오결제"
 
     fun toEntity(): TransferHistory {
         return TransferHistory(
             transferMoney,
             1L,
             1L,
-            TransferStatus.WITHDRAWAL
+            TransferStatus.WITHDRAWAL,
+            failCause
         )
     }
 
@@ -23,7 +25,8 @@ object TestTransferHistoryUtils {
             transferMoney,
             memberId,
             bankId,
-            TransferStatus.WITHDRAWAL
+            TransferStatus.WITHDRAWAL,
+            failCause
         )
     }
 }

--- a/src/test/kotlin/me/golf/kotlin/domain/bank/payment/application/PaymentQueueServiceTest.kt
+++ b/src/test/kotlin/me/golf/kotlin/domain/bank/payment/application/PaymentQueueServiceTest.kt
@@ -1,0 +1,45 @@
+package me.golf.kotlin.domain.bank.payment.application
+
+import io.mockk.mockk
+import me.golf.kotlin.domain.bank.model.BankAccountRepository
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.springframework.amqp.rabbit.core.RabbitTemplate
+
+internal class PaymentQueueServiceTest {
+
+    private val bankAccountRepository: BankAccountRepository = mockk()
+    private val rabbitTemplate: RabbitTemplate = mockk()
+    lateinit var paymentQueueService: PaymentQueueService
+    private val mockQueueName: String = "mockQueue"
+
+    @BeforeEach
+    fun setup() {
+        paymentQueueService = PaymentQueueService(bankAccountRepository, rabbitTemplate, mockQueueName, mockQueueName, "topic")
+    }
+
+    @Test
+    @DisplayName("finAccount 정보를 받아와 queue에 요청을 담아 처리한다.")
+    fun test1() {
+        // given
+
+        // when
+
+        // then
+
+    }
+
+    @Test
+    fun test2() {
+        // given
+
+
+        // when
+
+        // then
+
+    }
+}

--- a/src/test/kotlin/me/golf/kotlin/domain/bank/presentation/BankAccountControllerTest.kt
+++ b/src/test/kotlin/me/golf/kotlin/domain/bank/presentation/BankAccountControllerTest.kt
@@ -7,7 +7,7 @@ import me.golf.kotlin.domain.bank.application.BankAccountCommandService
 import me.golf.kotlin.domain.bank.application.BankAccountQueryService
 import me.golf.kotlin.domain.bank.dto.*
 import me.golf.kotlin.domain.bank.error.BankAccountException
-import me.golf.kotlin.domain.bank.history.application.TransferHistoryService
+import me.golf.kotlin.domain.bank.history.application.PaymentHistoryService
 import me.golf.kotlin.domain.bank.history.dto.HistorySummaryResponseDto
 import me.golf.kotlin.domain.bank.history.model.TransferStatus
 import me.golf.kotlin.domain.bank.history.model.utils.TestTransferHistoryUtils
@@ -22,7 +22,6 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.SliceImpl
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import java.time.LocalDate
 import java.time.LocalDateTime
 
 class BankAccountControllerTest {
@@ -31,12 +30,12 @@ class BankAccountControllerTest {
     private lateinit var bankAccountController: BankAccountController
     private val bankAccountCommandService = mockk<BankAccountCommandService>()
     private val bankAccountQueryService = mockk<BankAccountQueryService>()
-    private val transferHistoryService = mockk<TransferHistoryService>()
+    private val paymentHistoryService = mockk<PaymentHistoryService>()
 
     @BeforeEach
     fun init() {
         customUserDetails = CustomUserDetails.of(GivenMember.toMember())
-        bankAccountController = BankAccountController(bankAccountCommandService, bankAccountQueryService, transferHistoryService)
+        bankAccountController = BankAccountController(bankAccountCommandService, bankAccountQueryService, paymentHistoryService)
     }
 
     @Test
@@ -104,7 +103,7 @@ class BankAccountControllerTest {
         val resDtos = SliceImpl(arrayListOf(historySummaryResDto), PageRequest.of(0, 10), true)
 
         every { bankAccountQueryService.getBankAccountSummary(any(), any()) } returns summaryResDto
-        every { transferHistoryService.getHistories(any(), any(), any()) } returns SliceCustomResponse.of(resDtos)
+        every { paymentHistoryService.getHistories(any(), any(), any()) } returns SliceCustomResponse.of(resDtos)
 
         // when
         val result: ResponseEntity<BankAccountInfoResponseDto> = bankAccountController

--- a/src/test/kotlin/me/golf/kotlin/domain/bank/presentation/PaymentControllerTest.kt
+++ b/src/test/kotlin/me/golf/kotlin/domain/bank/presentation/PaymentControllerTest.kt
@@ -1,0 +1,69 @@
+package me.golf.kotlin.domain.bank.presentation
+
+import io.mockk.coJustRun
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import me.golf.kotlin.domain.bank.payment.application.PaymentQueueService
+import me.golf.kotlin.domain.bank.payment.dto.PaymentApiRequestDto
+import me.golf.kotlin.domain.bank.payment.dto.RefundApiRequestDto
+import me.golf.kotlin.domain.bank.payment.presentation.PaymentController
+import me.golf.kotlin.domain.member.util.GivenMember
+import me.golf.kotlin.global.security.CustomUserDetails
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+
+internal class PaymentControllerTest {
+
+    private val paymentQueueService: PaymentQueueService = mockk()
+    lateinit var paymentController: PaymentController
+    private val customUserDetails = CustomUserDetails.of(GivenMember.toMember())
+
+    @BeforeEach
+    fun setup() {
+        paymentController = PaymentController(paymentQueueService)
+    }
+
+    @Test
+    @DisplayName("결제 요청을 보내 성공하면 200 OK")
+    fun pay() {
+        // given
+        val requestDto = PaymentApiRequestDto(
+            bankId = 1L,
+            fromName = "테스트용 계좌2",
+            transferMoney = "10000"
+        )
+
+        coJustRun { paymentQueueService.pay(any()) }
+
+        // when
+        val result = runBlocking { paymentController.pay(requestDto, customUserDetails) }
+
+        // then
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+    }
+    
+    @Test
+    @DisplayName("환불 요청을 보내 성공하면 200 OK")
+    fun refund() {
+        // given
+        val requestDto = RefundApiRequestDto(
+            bankId = 1L,
+            accountNumber  = "31239129083",
+            bankName = "농협은행",
+            transferMoney = "10000",
+            refundCause = "오결제",
+            fromName = "소비자"
+        )
+
+        coJustRun { paymentQueueService.refund(any()) }
+
+        // when
+        val result = runBlocking { paymentController.refund(requestDto, customUserDetails) }
+
+        // that
+        assertThat(result.statusCode).isEqualTo(HttpStatus.OK)
+    }
+}


### PR DESCRIPTION
해결한 문제

1. 간편 결제 시 외부 서비스를 연동하기 때문에 자체 서비스에 영향을 주면 안됨. 
2. 영향을 안주는 거 뿐만 아니라 재시도를 할 수 있게 하고 많은 부하에도 견뎌야함 (처리가 지연되면 계속 큐에 쌓이게 되고 이럴 때 대책이 필요)

통신 에러 핸들링과 time out 설정으로 충분히 해결이 가능했지만 Message Queue를 사용하여 좀 더 세부적으로 다루고 싶었고 서비스 특성상 좀 더 독립적으로 동작하게 하거나 요청이 많을 것으로 생각 되기 때문에 클러스터링을 하여 부하도 분산할 수 있는 RabbitMQ를 선택하여 구현

또한 학습용으로도 사용해보고 싶어 사용 하게 됨.

### 구현 내용 

RabbitMQ 를 사용하여 비동기로 처리 이 때 실패 시 무한 재시도를 하기 때문에 부하나 성능을 고려하여 1분간 총 5번 시도하게 하는 Retry 설정을 하여 MQ 및 서버 부하 감소 또한 버그나 장애에 대응을 쉽게 하기 위해 durable = true 옵션을 주어 디스크에 저장하여 성능을 조금 저하 시키더라도 장애 추적에 용이하게 설계 

Exchange를 topic 방식으로 설정하여 큐와 라우팅 key를 1:N으로 설정하여 결제나 환불 관련하여 다른 요구사항이 생기더라도 유연하게 대처할 수 있도록 설계 (초기 direct 방식은 1:1 이기 때문에 유연한 설계에 불리함)